### PR TITLE
Refactor: Removed CachedVisibilityMap to use previous frame data, fixed another crash.

### DIFF
--- a/Source/SoftwareOC/Private/OcclusionSceneView.cpp
+++ b/Source/SoftwareOC/Private/OcclusionSceneView.cpp
@@ -78,7 +78,7 @@ void FOcclusionSceneViewExtension::PostRenderBasePassDeferred_RenderThread(FRDGB
 		return;
 	}
 	
-	if(Scene->World->IsBeingCleanedUp() || Scene->World->HasAnyFlags(RF_MirroredGarbage) || Scene->World->HasAnyFlags(RF_BeginDestroyed))
+	if(!Scene->World || !IsValid(Scene->World) || Scene->World->IsBeingCleanedUp() || Scene->World->HasAnyFlags(RF_MirroredGarbage) || Scene->World->HasAnyFlags(RF_BeginDestroyed))
 	{
 		return;
 	}
@@ -161,7 +161,7 @@ void FOcclusionSceneViewExtension::PostRenderBasePassDeferred_RenderThread(FRDGB
 				}
 
 				// Paranoid Sanity Check.
-				if(Scene->World->IsBeingCleanedUp() || Scene->World->HasAnyFlags(RF_MirroredGarbage) || Scene->World->HasAnyFlags(RF_BeginDestroyed))
+				if(!Scene->World || !IsValid(Scene->World) || Scene->World->IsBeingCleanedUp() || Scene->World->HasAnyFlags(RF_MirroredGarbage) || Scene->World->HasAnyFlags(RF_BeginDestroyed))
 				{
 					return;
 				}

--- a/Source/SoftwareOC/Private/OcclusionSceneView.cpp
+++ b/Source/SoftwareOC/Private/OcclusionSceneView.cpp
@@ -73,12 +73,7 @@ void FOcclusionSceneViewExtension::PostRenderBasePassDeferred_RenderThread(FRDGB
 
 	FScene* Scene = InView.ViewActor->GetWorld()->Scene->GetRenderScene();
 	
-	if (!Scene)
-	{
-		return;
-	}
-	
-	if(!Scene->World || !IsValid(Scene->World) || Scene->World->IsBeingCleanedUp() || Scene->World->HasAnyFlags(RF_MirroredGarbage) || Scene->World->HasAnyFlags(RF_BeginDestroyed))
+	if(!IsSceneWorldValid(Scene))
 	{
 		return;
 	}
@@ -97,19 +92,10 @@ void FOcclusionSceneViewExtension::PostRenderBasePassDeferred_RenderThread(FRDGB
 	for (TObjectIterator<UMeshComponent> MeshIterator; MeshIterator; ++MeshIterator)
 	{
 		UMeshComponent* Component = *MeshIterator;
-		if (!IsValid(Component) || !Component->IsRegistered() || !Component->GetWorld() ||
-			Component->GetWorld()->WorldType == EWorldType::Editor ||
-			Component->GetWorld()->WorldType == EWorldType::Inactive ||
-			Component->GetWorld() != OcSubsystem->GetWorld())
+		if (!USoftwareOCSubsystem::CheckComponentValidWorld(Component, OcSubsystem) ||
+			!USoftwareOCSubsystem::CheckComponentNotBeingDestroyed(Component))
 		{
 			continue;
-		}
-
-		// Paranoid sanity checks.
-		if(Component->GetWorld()->IsBeingCleanedUp() || Component->GetWorld()->HasAnyFlags(RF_MirroredGarbage) ||
-			Component->GetWorld()->HasAnyFlags(RF_BeginDestroyed) || !Component->GetWorld()->HasAnyFlags(RF_WasLoaded))
-		{
-			return;
 		}
 
 		// Now make sure that these components aren't marked to be ignored.
@@ -120,11 +106,6 @@ void FOcclusionSceneViewExtension::PostRenderBasePassDeferred_RenderThread(FRDGB
 		}
 
 		FPrimitiveComponentId ComponentId = Component->GetPrimitiveSceneId();
-
-		if(Component->HasAnyFlags(RF_ClassDefaultObject) || Component->HasAnyFlags(RF_MirroredGarbage) || Component->HasAnyFlags(RF_BeginDestroyed))
-		{
-			continue;
-		}
 
 		bool ObjectHidden = !FrameResults->IsVisible(ComponentId);
 
@@ -138,10 +119,7 @@ void FOcclusionSceneViewExtension::PostRenderBasePassDeferred_RenderThread(FRDGB
 		if(!ObjectHidden)
 		{
 			// This is to fix animations not playing in UE5.5 when occlusion culling is off.
-			if(Component->GetWorld())
-			{
-				Component->GetSceneData().SetLastRenderTime(Component->GetWorld()->GetTimeSeconds(), true);
-			}
+			Component->GetSceneData().SetLastRenderTime(Component->GetWorld()->GetTimeSeconds(), true);
 		}
 
 		// We shouldn't tell the GameThead to launch a task to set visibility if we haven't changed.
@@ -152,21 +130,14 @@ void FOcclusionSceneViewExtension::PostRenderBasePassDeferred_RenderThread(FRDGB
 			{
 				// Objects can start to die in this frame (since it runs 1 frame later than the code outside of this task).
 				// We detect them here and stop processing them if so.
-				if(!Component || !Component->IsRegistered() || Component->HasAnyFlags(RF_MirroredGarbage) ||
-					Component->HasAnyFlags(RF_BeginDestroyed) ||
-					!Component->GetWorld()->HasAnyFlags(RF_WasLoaded) ||
-					Component->IsBeingDestroyed())
+				if (!USoftwareOCSubsystem::CheckComponentValidWorld(Component, OcSubsystem) ||
+					!USoftwareOCSubsystem::CheckComponentNotBeingDestroyed(Component))
 				{
 					return;
 				}
 
 				// Paranoid Sanity Check.
-				if(!Scene->World || !IsValid(Scene->World) || Scene->World->IsBeingCleanedUp() || Scene->World->HasAnyFlags(RF_MirroredGarbage) || Scene->World->HasAnyFlags(RF_BeginDestroyed))
-				{
-					return;
-				}
-				
-				if(!IsValid(Component) || !Component->GetWorld())
+				if(!IsSceneWorldValid(Scene))
 				{
 					return;
 				}
@@ -184,7 +155,7 @@ void FOcclusionSceneViewExtension::PostRenderBasePassDeferred_RenderThread(FRDGB
 				OccludedColour = FColor::Yellow;
 			}
 
-			// DrawDebugBox throws an error if we try draw immediately. We should until the world has been alive
+			// DrawDebugBox throws an error if we try draw immediately. We should wait until the world has been alive
 			// for a bit to actually draw debug stuff.
 			if(Component->GetWorld() && Component->GetWorld()->GetRealTimeSeconds() >= 1)
 			{
@@ -218,4 +189,10 @@ void FOcclusionSceneViewExtension::PostRenderBasePassDeferred_RenderThread(FRDGB
 	const FScreenPassRenderTarget Output(ViewFamilyTexture, View->UnconstrainedViewRect, ERenderTargetLoadAction::ELoad);
 	
 	SceneSoftwareOcclusion->DebugDraw(GraphBuilder, *View, Output, 20, 20);
+}
+
+bool FOcclusionSceneViewExtension::IsSceneWorldValid(const FScene* InScene)
+{
+	return InScene && InScene->World && IsValid(InScene->World) && !InScene->World->IsBeingCleanedUp() && !InScene->World->HasAnyFlags(RF_BeginDestroyed) &&
+		InScene->World->HasAnyFlags(RF_WasLoaded);
 }

--- a/Source/SoftwareOC/Private/SoftwareOCSubsystem.cpp
+++ b/Source/SoftwareOC/Private/SoftwareOCSubsystem.cpp
@@ -28,6 +28,11 @@ void USoftwareOCSubsystem::Deinitialize()
 {
 	Super::Deinitialize();
 
+	Reset();
+}
+
+void USoftwareOCSubsystem::Reset()
+{
 	IDToMeshComp = {};
 
 	if(OcclusionSceneViewExtension)
@@ -59,27 +64,42 @@ void USoftwareOCSubsystem::Tick(float DeltaTime)
 	ForceUpdateMap();
 }
 
+bool USoftwareOCSubsystem::CheckComponentValidWorld(UMeshComponent* Component, UObject* Context)
+{
+	return Component->IsValidLowLevel() && Context->IsValidLowLevel() &&
+			IsValid(Component) && IsValid(Context) &&
+			Component->IsRegistered() &&
+			Component->GetWorld() && Context->GetWorld() &&
+			Component->GetWorld()->WorldType != EWorldType::Editor &&
+			Component->GetWorld()->WorldType != EWorldType::Inactive &&
+			Component->GetWorld() == Context->GetWorld();
+}
+
+bool USoftwareOCSubsystem::CheckComponentNotBeingDestroyed(UMeshComponent* Component)
+{
+	return IsValid(Component) && !Component->GetWorld()->IsBeingCleanedUp() &&
+			!Component->GetWorld()->HasAnyFlags(RF_BeginDestroyed) && Component->GetWorld()->HasAnyFlags(RF_WasLoaded);
+}
+
 void USoftwareOCSubsystem::ForceUpdateMap()
 {
-	// Empty list just incase it's got dangling pointers (Shouldn't but never worth the risk).
-	IDToMeshComp.Empty();
+	if(!GetWorld() || !IsValid(GetWorld()))
+	{
+		return;
+	}
 	
 	for(TObjectIterator<UMeshComponent> MeshItr; MeshItr; ++MeshItr)
 	{
 		UMeshComponent* Component = *MeshItr;
-		if (!IsValid(Component) || !Component->IsRegistered() || !Component->GetWorld() ||
-			Component->GetWorld()->WorldType == EWorldType::Editor ||
-			Component->GetWorld()->WorldType == EWorldType::Inactive ||
-			Component->GetWorld() != GetWorld())
+		if (!CheckComponentValidWorld(Component, this))
 		{
 			continue;
 		}
 
 		// Paranoid sanity checks.
-		if(Component->GetWorld()->IsBeingCleanedUp() || Component->GetWorld()->HasAnyFlags(RF_MirroredGarbage) ||
-			Component->GetWorld()->HasAnyFlags(RF_BeginDestroyed) || !Component->GetWorld()->HasAnyFlags(RF_WasLoaded))
+		if(!CheckComponentNotBeingDestroyed(Component))
 		{
-			return;
+			continue;
 		}
 
 		// Now make sure that these components aren't marked to be ignored.

--- a/Source/SoftwareOC/Private/Unreal/SceneSoftwareOcclusion.cpp
+++ b/Source/SoftwareOC/Private/Unreal/SceneSoftwareOcclusion.cpp
@@ -1160,14 +1160,14 @@ int32 FSceneSoftwareOcclusion::Process(const FScene* Scene, FViewInfo& View)
 	// Finished processing occlusion, set results as available
 	Available = MoveTemp(Processing);
 
-	// Submit occlusion scene for next frame
-	Processing = MakeUnique<FOcclusionFrameResults>();
-
 	// Ensure we aren't about to run with the world shutting down.
 	if(Scene->World->IsBeingCleanedUp() || Scene->World->HasAnyFlags(RF_MirroredGarbage) || Scene->World->HasAnyFlags(RF_BeginDestroyed))
 	{
 		return 0;
 	}
+
+	// Submit occlusion scene for next frame
+	Processing = MakeUnique<FOcclusionFrameResults>();
 	
 	TaskRef = SubmitScene(Scene, View, Processing.Get());
 

--- a/Source/SoftwareOC/Private/Unreal/SceneSoftwareOcclusion.cpp
+++ b/Source/SoftwareOC/Private/Unreal/SceneSoftwareOcclusion.cpp
@@ -965,7 +965,7 @@ FGraphEventRef FSceneSoftwareOcclusion::SubmitScene(const FScene* Scene, const F
 	int32 NumCollectedOccluders = 0;
 	int32 NumCollectedOccludees = 0;
 	
-	if(!Scene->World || !IsValid(Scene->World) || Scene->World->IsBeingCleanedUp() || Scene->World->HasAnyFlags(RF_MirroredGarbage) || Scene->World->HasAnyFlags(RF_BeginDestroyed))
+	if(!FOcclusionSceneViewExtension::IsSceneWorldValid(Scene))
 	{
 		return FGraphEventRef();
 	}
@@ -1038,21 +1038,26 @@ FGraphEventRef FSceneSoftwareOcclusion::SubmitScene(const FScene* Scene, const F
         
             if (bCanBeOccluder)
             {
-            	FPotentialOccluderPrimitive PotentialOccluder{};
-
-            	PotentialOccluder.PrimitiveSceneInfo = PrimitiveSceneInfo;
-
-            	if (OcSubsystem && OcSubsystem->IDToMeshComp.Contains(PrimitiveComponentId.PrimIDValue))
+            	if (OcSubsystem && OcSubsystem->IDToMeshComp.Find(PrimitiveComponentId.PrimIDValue) != nullptr)
             	{
-		            if(auto StaticMeshComponent = Cast<UStaticMeshComponent>(*OcSubsystem->IDToMeshComp.Find(PrimitiveComponentId.PrimIDValue)))
+            		if(auto StaticMeshComponent = Cast<UStaticMeshComponent>(*OcSubsystem->IDToMeshComp.Find(PrimitiveComponentId.PrimIDValue)))
             		{
-            			PotentialOccluder.OccluderData = FOcclusionMeshData(StaticMeshComponent->GetStaticMesh());
+            			if (USoftwareOCSubsystem::CheckComponentValidWorld(StaticMeshComponent, OcSubsystem) &&
+            				USoftwareOCSubsystem::CheckComponentNotBeingDestroyed(StaticMeshComponent))
+            			{
+            				FPotentialOccluderPrimitive PotentialOccluder{};
+            				
+            				PotentialOccluder.PrimitiveSceneInfo = PrimitiveSceneInfo;
+            				PotentialOccluder.OccluderData = FOcclusionMeshData(StaticMeshComponent->GetStaticMesh());
+            				if(PotentialOccluder.OccluderData.MeshDataCorrectlySet)
+            				{
+            					PotentialOccluder.Weight = ComputePotentialOccluderWeight(ScreenSize, DistanceSquared);
+
+            					PotentialOccluders.Add(PotentialOccluder);
+            				}
+            			}
             		}
             	}
-
-            	PotentialOccluder.Weight = ComputePotentialOccluderWeight(ScreenSize, DistanceSquared);
-
-            	PotentialOccluders.Add(PotentialOccluder);
             }
         
             bool bCanBeOccludee = !bHasHugeBounds && Proxy->CanBeOccluded() && (OcclusionFlags & EOcclusionFlags::CanBeOccluded) != 0;
@@ -1063,8 +1068,7 @@ FGraphEventRef FSceneSoftwareOcclusion::SubmitScene(const FScene* Scene, const F
             	NumCollectedOccludees++;
             }
 		}
-
-		/*
+		
 		// Check previous frame's data.
 		// We do a check for OCSubsystem as it's null for the first frame and we require it to get the Mesh Comp.
 		if (OcSubsystem && Available.IsValid() && !Available.Get()->VisibilityMap.IsEmpty())
@@ -1083,9 +1087,7 @@ FGraphEventRef FSceneSoftwareOcclusion::SubmitScene(const FScene* Scene, const F
 				}
 				UMeshComponent* MeshComponent = *OcSubsystem->IDToMeshComp.Find(PrimitiveComponentId.PrimIDValue);
 
-				if(!MeshComponent || !IsValid(MeshComponent) ||
-					MeshComponent->HasAnyFlags(RF_MirroredGarbage) ||
-					MeshComponent->HasAnyFlags(RF_BeginDestroyed))
+				if (!USoftwareOCSubsystem::CheckComponentNotBeingDestroyed(MeshComponent))
 				{
 					continue;
 				}
@@ -1100,7 +1102,6 @@ FGraphEventRef FSceneSoftwareOcclusion::SubmitScene(const FScene* Scene, const F
 				NumCollectedOccludees++;
 			}
 		}
-		*/
 
 		// Sort potential occluders by weight
 		PotentialOccluders.Sort([&](const FPotentialOccluderPrimitive& A, const FPotentialOccluderPrimitive& B) { 
@@ -1140,7 +1141,7 @@ FGraphEventRef FSceneSoftwareOcclusion::SubmitScene(const FScene* Scene, const F
 	
 	// Submit occlusion task
 	FOcclusionSceneData* SceneDataParam = SceneData.Release();
-	return FFunctionGraphTask::CreateAndDispatchWhenReady([SceneDataParam, Results]()
+	return FFunctionGraphTask::CreateAndDispatchWhenReady([Scene, SceneDataParam, Results]()
 	{
 		ProcessOcclusionFrame(*SceneDataParam, *Results);
 		delete SceneDataParam;
@@ -1161,7 +1162,7 @@ int32 FSceneSoftwareOcclusion::Process(const FScene* Scene, FViewInfo& View)
 	Available = MoveTemp(Processing);
 
 	// Ensure we aren't about to run with the world shutting down.
-	if(!Scene->World || !IsValid(Scene->World) || Scene->World->IsBeingCleanedUp() || Scene->World->HasAnyFlags(RF_MirroredGarbage) || Scene->World->HasAnyFlags(RF_BeginDestroyed))
+	if(!FOcclusionSceneViewExtension::IsSceneWorldValid(Scene))
 	{
 		return 0;
 	}

--- a/Source/SoftwareOC/Public/OcclusionSceneView.h
+++ b/Source/SoftwareOC/Public/OcclusionSceneView.h
@@ -24,4 +24,6 @@ public:
 	
 	TArray<bool>* SubIsOccluded = nullptr;
 	USoftwareOCSubsystem* OcSubsystem = nullptr;
+
+	static bool IsSceneWorldValid(const FScene* InScene);
 };

--- a/Source/SoftwareOC/Public/SoftwareOCSubsystem.h
+++ b/Source/SoftwareOC/Public/SoftwareOCSubsystem.h
@@ -27,14 +27,6 @@ public:
 	UPROPERTY()
 	TMap<uint32, TObjectPtr<UMeshComponent>> IDToMeshComp;
 
-	// Objects that we've culled.
-	// This will always return true (false objects are removed). Using Map on purpose for scaling reasons.
-	TMap<FPrimitiveComponentId, bool> CachedVisibilityMap;
-
-	// This is purely for objects that are meant to be hidden by the game/user
-	// This prevents cameras and whatnot from showing when they're not meant to.
-	TMap<FPrimitiveComponentId, bool> CachedHiddenMap;
-
 	void ForceUpdateMap();
 
 private:

--- a/Source/SoftwareOC/Public/SoftwareOCSubsystem.h
+++ b/Source/SoftwareOC/Public/SoftwareOCSubsystem.h
@@ -17,11 +17,18 @@ public:
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	virtual void Deinitialize() override;
 
+	void Reset();
+
 	virtual TStatId GetStatId() const override;
 
 	virtual bool IsTickable() const override;
 	
 	virtual void Tick(float DeltaTime) override;
+
+	// Context should always be the subsystem
+	static bool CheckComponentValidWorld(UMeshComponent* Component, UObject* Context);
+
+	static bool CheckComponentNotBeingDestroyed(UMeshComponent* Component);
 
 	// We store as uint32 because UPROPERTY doesn't like FPrimitiveComponentId
 	UPROPERTY()

--- a/Source/SoftwareOC/Public/Unreal/FOcclusionFrameResults.h
+++ b/Source/SoftwareOC/Public/Unreal/FOcclusionFrameResults.h
@@ -19,7 +19,7 @@ struct FOcclusionFrameResults
 	{
 		if(!VisibilityMap.Contains(ID))
 		{
-			return true; // Assume that any mesh that isn't in this list, should be visible.
+			return true;
 		}
 		
 		return *VisibilityMap.Find(ID);

--- a/Source/SoftwareOC/Public/Unreal/FOcclusionFrameResults.h
+++ b/Source/SoftwareOC/Public/Unreal/FOcclusionFrameResults.h
@@ -19,7 +19,7 @@ struct FOcclusionFrameResults
 	{
 		if(!VisibilityMap.Contains(ID))
 		{
-			return true;
+			return true; // Assume that any mesh that isn't in this list, should be visible.
 		}
 		
 		return *VisibilityMap.Find(ID);

--- a/Source/SoftwareOC/Public/Unreal/OcclusionMeshData.h
+++ b/Source/SoftwareOC/Public/Unreal/OcclusionMeshData.h
@@ -37,8 +37,15 @@ public:
 			const FVector3f* V0 = &LODModel.VertexBuffers.PositionVertexBuffer.VertexPosition(0);
 			const uint16* Indices = IndexBuffer.AccessStream16();
 
-			FMemory::Memcpy(VerticesSP.GetData(), V0, NumVtx * sizeof(FVector3f));
-			FMemory::Memcpy(IndicesSP.GetData(), Indices, NumIndices * sizeof(uint16));
+			if (V0)
+			{
+				FMemory::Memcpy(VerticesSP.GetData(), V0, NumVtx * sizeof(FVector3f));
+			}
+
+			if (Indices)
+			{
+				FMemory::Memcpy(IndicesSP.GetData(), Indices, NumIndices * sizeof(uint16));
+			}
 		}
 	}
 

--- a/Source/SoftwareOC/Public/Unreal/OcclusionMeshData.h
+++ b/Source/SoftwareOC/Public/Unreal/OcclusionMeshData.h
@@ -37,15 +37,22 @@ public:
 			const FVector3f* V0 = &LODModel.VertexBuffers.PositionVertexBuffer.VertexPosition(0);
 			const uint16* Indices = IndexBuffer.AccessStream16();
 
-			if (V0)
+			if (!V0)
 			{
-				FMemory::Memcpy(VerticesSP.GetData(), V0, NumVtx * sizeof(FVector3f));
+				UE_LOG(LogTemp, Warning, TEXT("Vertex Buffer returned null. Mesh %s will be removed from Occluders."), *GetNameSafe(Mesh));
+				return;
 			}
 
-			if (Indices)
+			if (!Indices)
 			{
-				FMemory::Memcpy(IndicesSP.GetData(), Indices, NumIndices * sizeof(uint16));
+				UE_LOG(LogTemp, Warning, TEXT("Index Buffer returned null. Mesh %s will be removed from Occluders."), *GetNameSafe(Mesh));
+				return;
 			}
+			
+			FMemory::Memcpy(VerticesSP.GetData(), V0, NumVtx * sizeof(FVector3f));
+			FMemory::Memcpy(IndicesSP.GetData(), Indices, NumIndices * sizeof(uint16));
+			
+			MeshDataCorrectlySet = true;
 		}
 	}
 
@@ -57,6 +64,8 @@ public:
 	TArray<uint16>			IndicesSP{};
 	
 	FPrimitiveComponentId	PrimId; // Has a zero constructor.
+
+	bool MeshDataCorrectlySet{ false };
 };
 
 struct FPotentialOccluderPrimitive


### PR DESCRIPTION
This PR removes the CachedVisibilityMap to use the previous frame's data to check if objects should still be occluded or not.

This saves, at a minimum, 188 bytes of memory. In a scene with 1000 objects (this is quite easy to hit, reminder, each Static Mesh inside of a blueprint is another object), this is roughly ((9*1000)+188)=9188 bytes (9.1KBs) of memory (9 is the size of FPrimitiveSceneID + bool), actual saved memory might be smaller or bigger, depends on usage.

This PR also stops sending every object in the FrameResult's VisibilityMap to the GameThread if it hasn't changed. This improves the frame time quite a lot in a heavy populated world (I've seen about a ~0.2-0.4ms improvement in my [test scene](https://www.youtube.com/watch?v=h-qDpoOg8SA)), as we no longer send a task for every object in the world, only ones that need to be occluded (and if their visibility doesn't match what the occluder wants).

Closes #1 

